### PR TITLE
Robots txt parsing

### DIFF
--- a/internal/robots.go
+++ b/internal/robots.go
@@ -47,6 +47,7 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 				rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
 			} 
 
+			rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
 			currentBlock = RobotRuleBlock{}
 			continue
 		}
@@ -57,7 +58,21 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 		lineParts := strings.Split(line, ": ")
 		if len(lineParts) != 2 {
 			err = &RobotSyntaxError{"Unexpected ':' right here."}
+			return
 		}
+
+		// Pretty sure the key is case insensitive, so we can just do this.
+		key := strings.ToLower(lineParts[0])
+		value := lineParts[1]
+
+		switch key {
+		case "user-agent":
+			currentBlock.UserAgents = append(currentBlock.UserAgents, value)
+		case "disallow":
+			currentBlock.DisallowedURLs = append(currentBlock.DisallowedURLs, value)
+		}
+		
+		// When we run into an unknown key we just ignore it lol
 	}
 
 	return

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -71,7 +71,6 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 				rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
 			}
 
-			rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
 			currentBlock = RobotRuleBlock{}
 			continue
 		}
@@ -97,6 +96,10 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 		}
 
 		// When we run into an unknown key we just ignore it lol
+	}
+
+	if !currentBlock.IsEmpty() {
+		rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
 	}
 
 	return

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -1,0 +1,64 @@
+package internal
+
+import (
+	"io"
+	"strings"
+)
+
+type RobotRuleBlock struct {
+	UserAgents []string
+	DisallowedURLs []string
+}
+
+type RobotRules struct {
+	RuleBlocks []RobotRuleBlock
+	Sitemap string
+}
+
+type RobotSyntaxError struct {
+	Details string
+}
+
+func (err *RobotSyntaxError) Error() string {
+	return err.Details
+}
+
+func (block *RobotRuleBlock) IsEmpty() bool {
+	return len(block.DisallowedURLs) == 0
+}
+
+func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
+	robotsFile, err := io.ReadAll(reader)
+	if err != nil {
+		return
+	}
+
+	currentBlock := RobotRuleBlock{}
+
+	for line := range strings.Lines(string(robotsFile)) {
+		// Comments
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Blank lines
+		if strings.TrimSpace(line) == "" {
+			if !currentBlock.IsEmpty() {
+				rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
+			} 
+
+			currentBlock = RobotRuleBlock{}
+			continue
+		}
+
+		// TODO: Maybe do some more error checking?
+
+		// Normal lines
+		lineParts := strings.Split(line, ": ")
+		if len(lineParts) != 2 {
+			err = &RobotSyntaxError{"Unexpected ':' right here."}
+		}
+	}
+
+	return
+}

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -104,3 +104,29 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 
 	return
 }
+
+// Since it seems like stripping the prefix and stuff would be too difficult,
+// I decided that you are going to do that manually before calling this function.
+// Therefore, do not worry if you don't end up dying from this shit hole
+func MatchURLRule(url string, rule string) bool {
+	urlParts := strings.Split(url, "/")
+	ruleParts := strings.Split(rule, "/")
+
+	// Obviously if they have different parts they won't match.
+	if len(urlParts) != len(ruleParts) {
+		return false
+	}
+
+	for i, urlPart := range(urlParts) {
+		// '*' matches anything
+		if ruleParts[i] == "*" {
+			continue
+		}
+
+		if ruleParts[i] != urlPart {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -6,13 +6,13 @@ import (
 )
 
 type RobotRuleBlock struct {
-	UserAgents []string
+	UserAgents     []string
 	DisallowedURLs []string
 }
 
 type RobotRules struct {
 	RuleBlocks []RobotRuleBlock
-	Sitemap string
+	Sitemap    string
 }
 
 type RobotSyntaxError struct {
@@ -69,7 +69,7 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 		if strings.TrimSpace(line) == "" {
 			if !currentBlock.IsEmpty() {
 				rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
-			} 
+			}
 
 			rules.RuleBlocks = append(rules.RuleBlocks, currentBlock)
 			currentBlock = RobotRuleBlock{}
@@ -87,7 +87,7 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 
 		// Pretty sure the key is case insensitive, so we can just do this.
 		key := strings.ToLower(lineParts[0])
-		value := lineParts[1]
+		value := strings.TrimSpace(lineParts[1])
 
 		switch key {
 		case "user-agent":
@@ -95,7 +95,7 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 		case "disallow":
 			currentBlock.DisallowedURLs = append(currentBlock.DisallowedURLs, value)
 		}
-		
+
 		// When we run into an unknown key we just ignore it lol
 	}
 

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -27,6 +27,30 @@ func (block *RobotRuleBlock) IsEmpty() bool {
 	return len(block.DisallowedURLs) == 0
 }
 
+// This is only for testing purposes only - I don't see when we would
+// ever use this in any actual code lol.
+func (rules *RobotRules) IsEqual(b *RobotRules) bool {
+	for i, block := range rules.RuleBlocks {
+		for j, agent := range block.UserAgents {
+			if b.RuleBlocks[i].UserAgents[j] != agent {
+				return false
+			}
+		}
+
+		for j, disallow := range block.DisallowedURLs {
+			if b.RuleBlocks[i].DisallowedURLs[j] != disallow {
+				return false
+			}
+		}
+	}
+
+	if rules.Sitemap != b.Sitemap {
+		return false
+	}
+
+	return true
+}
+
 func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 	robotsFile, err := io.ReadAll(reader)
 	if err != nil {

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -3,11 +3,12 @@ package internal
 import (
 	"io"
 	"strings"
+	"regexp"
 )
 
 type RobotRuleBlock struct {
 	UserAgents     []string
-	DisallowedURLs []string
+	DisallowedURLs []*regexp.Regexp
 }
 
 type RobotRules struct {
@@ -38,7 +39,7 @@ func (rules *RobotRules) IsEqual(b *RobotRules) bool {
 		}
 
 		for j, disallow := range block.DisallowedURLs {
-			if b.RuleBlocks[i].DisallowedURLs[j] != disallow {
+			if b.RuleBlocks[i].DisallowedURLs[j].String() != disallow.String() {
 				return false
 			}
 		}
@@ -92,7 +93,12 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 		case "user-agent":
 			currentBlock.UserAgents = append(currentBlock.UserAgents, value)
 		case "disallow":
-			currentBlock.DisallowedURLs = append(currentBlock.DisallowedURLs, value)
+			regex, err := regexp.Compile(value)
+			if err != nil {
+				err = &RobotSyntaxError{"Invalid regex"}
+				return RobotRules {}, err
+			}
+			currentBlock.DisallowedURLs = append(currentBlock.DisallowedURLs, regex)
 		}
 
 		// When we run into an unknown key we just ignore it lol
@@ -108,25 +114,11 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 // Since it seems like stripping the prefix and stuff would be too difficult,
 // I decided that you are going to do that manually before calling this function.
 // Therefore, do not worry if you don't end up dying from this shit hole
-func MatchURLRule(url string, rule string) bool {
-	urlParts := strings.Split(url, "/")
-	ruleParts := strings.Split(rule, "/")
-
-	// Obviously if they have different parts they won't match.
-	if len(urlParts) != len(ruleParts) {
-		return false
+func MatchURLRule(url string, rule *regexp.Regexp) bool {
+	// This covers specifically one of the cases
+	if strings.HasSuffix(rule.String(), "/") {
+		return strings.HasPrefix(url, rule.String())
 	}
 
-	for i, urlPart := range(urlParts) {
-		// '*' matches anything
-		if ruleParts[i] == "*" {
-			continue
-		}
-
-		if ruleParts[i] != urlPart {
-			return false
-		}
-	}
-
-	return true
+	return rule.MatchString(url)
 }

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -2,8 +2,8 @@ package internal
 
 import (
 	"io"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 type RobotRuleBlock struct {
@@ -96,7 +96,7 @@ func ParseRobotTxt(reader io.Reader) (rules RobotRules, err error) {
 			regex, err := regexp.Compile(value)
 			if err != nil {
 				err = &RobotSyntaxError{"Invalid regex"}
-				return RobotRules {}, err
+				return RobotRules{}, err
 			}
 			currentBlock.DisallowedURLs = append(currentBlock.DisallowedURLs, regex)
 		}

--- a/internal/robots_test.go
+++ b/internal/robots_test.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"testing"
+	"strings"
+)
+
+func TestRobotParsing(t *testing.T) {
+	input := `User-agent: Neng Li
+Disallow: /yes/no
+Disallow: /bozo
+
+User-agent: Indeed
+Disallow: /no/`
+
+	obtained, err := ParseRobotTxt(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("It encountered an error while parsing: %v\n", err)
+	}
+
+	expected := RobotRules {
+		RuleBlocks: []RobotRuleBlock{
+			{
+				UserAgents: []string{"Neng Li"},
+				DisallowedURLs: []string{"/yes/no", "/bozo"},
+			},
+			{
+				UserAgents: []string{"Indeed"},
+				DisallowedURLs: []string{"/no/"},
+			},
+		},
+		Sitemap: "",
+	}
+
+	if !expected.IsEqual(&obtained) {
+		t.Errorf("Expected:\n%v\n\nGot:\n%v\n", expected, obtained)
+	}
+}

--- a/internal/robots_test.go
+++ b/internal/robots_test.go
@@ -36,3 +36,21 @@ Disallow: /no/`
 		t.Errorf("Expected:\n%v\n\nGot:\n%v\n", expected, obtained)
 	}
 }
+
+func TestURLMatching(t *testing.T) {
+	if !MatchURLRule("/hello/world", "/*/world") {
+		t.Errorf("First assertion failed!")
+	}
+
+	if MatchURLRule("/hello/world", "/goodbye/world") {
+		t.Errorf("Second assertion failed!")
+	}
+
+	if !MatchURLRule("/hello/world", "/hello/world") {
+		t.Errorf("Third assertion failed!")
+	}
+
+	if !MatchURLRule("/hello/world", "/hello/*") {
+		t.Errorf("Fourth assertion failed!")
+	}
+}

--- a/internal/robots_test.go
+++ b/internal/robots_test.go
@@ -11,7 +11,10 @@ func TestRobotParsing(t *testing.T) {
 Disallow: /yes/no
 Disallow: /bozo
 
+# Comment
 User-agent: Indeed
+User-agent: Interesting
+# Comment
 Disallow: /no/`
 
 	obtained, err := ParseRobotTxt(strings.NewReader(input))
@@ -23,14 +26,14 @@ Disallow: /no/`
 	bozoRule, _ := regexp.Compile("/bozo")
 	noRule, _ := regexp.Compile("/no/")
 
-	expected := RobotRules {
+	expected := RobotRules{
 		RuleBlocks: []RobotRuleBlock{
 			{
-				UserAgents: []string{"Neng Li"},
+				UserAgents:     []string{"Neng Li"},
 				DisallowedURLs: []*regexp.Regexp{yesNoRule, bozoRule},
 			},
 			{
-				UserAgents: []string{"Indeed"},
+				UserAgents:     []string{"Indeed", "Interesting"},
 				DisallowedURLs: []*regexp.Regexp{noRule},
 			},
 		},
@@ -43,33 +46,36 @@ Disallow: /no/`
 }
 
 func TestURLMatching(t *testing.T) {
-	rule, _ := regexp.Compile("/*/world")
-	if !MatchURLRule("/hello/world", rule) {
-		t.Errorf("First assertion failed!")
+	tests := map[int]struct {
+		Rule     string
+		URL      string
+		Expected bool
+	}{
+		1:  {Rule: "/*/world", URL: "/hello/world", Expected: true},
+		2:  {Rule: "/goodbye/world", URL: "/hello/world", Expected: false},
+		3:  {Rule: "/hello/world", URL: "/hello/world", Expected: true},
+		4:  {Rule: "/hello/*", URL: "/hello/world", Expected: true},
+		5:  {Rule: "/", URL: "/hello/world", Expected: true},
+		6:  {Rule: "/hello/", URL: "/hello/world", Expected: true},
+		7:  {Rule: "/Hello/World", URL: "/hello/world", Expected: false}, // case sensitivity
+		8:  {Rule: "/hello/$", URL: "/hello/world/hi", Expected: false},  // anchored end
+		9:  {Rule: "/hello$", URL: "/hello", Expected: true},             // end anchor match
+		10: {Rule: "/*.php$", URL: "/index.php", Expected: true},
+		11: {Rule: "/*.php$", URL: "/index.php?parameter", Expected: false},
+		12: {Rule: "/$", URL: "/", Expected: true},
+		13: {Rule: "/$", URL: "/hello", Expected: false},
 	}
 
-	rule, _ = regexp.Compile("/goodbye/world")
-	if MatchURLRule("/hello/world", rule) {
-		t.Errorf("Second assertion failed!")
-	}
-
-	rule, _ = regexp.Compile("/hello/world")
-	if !MatchURLRule("/hello/world", rule) {
-		t.Errorf("Third assertion failed!")
-	}
-
-	rule, _ = regexp.Compile("/hello/*")
-	if !MatchURLRule("/hello/world", rule) {
-		t.Errorf("Fourth assertion failed!")
-	}
-
-	rule, _ = regexp.Compile("/")
-	if !MatchURLRule("/hello/world", rule) {
-		t.Errorf("Fourth assertion failed!")
-	}
-
-	rule, _ = regexp.Compile("/hello/")
-	if !MatchURLRule("/hello/world", rule) {
-		t.Errorf("Fourth assertion failed!")
+	for id, test := range tests {
+		rule, err := regexp.Compile(test.Rule)
+		if err != nil {
+			t.Errorf("Test %d: failed to compile regex %q: %v", id, test.Rule, err)
+			continue
+		}
+		result := MatchURLRule(test.URL, rule)
+		if result != test.Expected {
+			t.Errorf("Test %d: rule=%q, url=%q, expected %t, got %t",
+				id, test.Rule, test.URL, test.Expected, result)
+		}
 	}
 }

--- a/internal/robots_test.go
+++ b/internal/robots_test.go
@@ -62,4 +62,14 @@ func TestURLMatching(t *testing.T) {
 	if !MatchURLRule("/hello/world", rule) {
 		t.Errorf("Fourth assertion failed!")
 	}
+
+	rule, _ = regexp.Compile("/")
+	if !MatchURLRule("/hello/world", rule) {
+		t.Errorf("Fourth assertion failed!")
+	}
+
+	rule, _ = regexp.Compile("/hello/")
+	if !MatchURLRule("/hello/world", rule) {
+		t.Errorf("Fourth assertion failed!")
+	}
 }

--- a/internal/robots_test.go
+++ b/internal/robots_test.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"testing"
+	"regexp"
 	"strings"
+	"testing"
 )
 
 func TestRobotParsing(t *testing.T) {
@@ -18,15 +19,19 @@ Disallow: /no/`
 		t.Fatalf("It encountered an error while parsing: %v\n", err)
 	}
 
+	yesNoRule, _ := regexp.Compile("/yes/no")
+	bozoRule, _ := regexp.Compile("/bozo")
+	noRule, _ := regexp.Compile("/no/")
+
 	expected := RobotRules {
 		RuleBlocks: []RobotRuleBlock{
 			{
 				UserAgents: []string{"Neng Li"},
-				DisallowedURLs: []string{"/yes/no", "/bozo"},
+				DisallowedURLs: []*regexp.Regexp{yesNoRule, bozoRule},
 			},
 			{
 				UserAgents: []string{"Indeed"},
-				DisallowedURLs: []string{"/no/"},
+				DisallowedURLs: []*regexp.Regexp{noRule},
 			},
 		},
 		Sitemap: "",
@@ -38,19 +43,23 @@ Disallow: /no/`
 }
 
 func TestURLMatching(t *testing.T) {
-	if !MatchURLRule("/hello/world", "/*/world") {
+	rule, _ := regexp.Compile("/*/world")
+	if !MatchURLRule("/hello/world", rule) {
 		t.Errorf("First assertion failed!")
 	}
 
-	if MatchURLRule("/hello/world", "/goodbye/world") {
+	rule, _ = regexp.Compile("/goodbye/world")
+	if MatchURLRule("/hello/world", rule) {
 		t.Errorf("Second assertion failed!")
 	}
 
-	if !MatchURLRule("/hello/world", "/hello/world") {
+	rule, _ = regexp.Compile("/hello/world")
+	if !MatchURLRule("/hello/world", rule) {
 		t.Errorf("Third assertion failed!")
 	}
 
-	if !MatchURLRule("/hello/world", "/hello/*") {
+	rule, _ = regexp.Compile("/hello/*")
+	if !MatchURLRule("/hello/world", rule) {
 		t.Errorf("Fourth assertion failed!")
 	}
 }


### PR DESCRIPTION
Added support for parsing the robots.txt file when crawling a website.
For now, however, this only has basic capabilities, due to the lack of other features that are implemented (there still is a lack of solid crawler architecture, which is why I haven't integrated the parser into the rest of the program).

It also adds support for matching URLs with patterns, although only the very basic pattern matching that is supported by the official robots.txt specification.